### PR TITLE
Work with rspec 3.0.3

### DIFF
--- a/lib/generative/dsl.rb
+++ b/lib/generative/dsl.rb
@@ -1,10 +1,6 @@
 class RSpec::Core::ExampleGroup
-  def self.generative(name = nil, &block)
-    name = "(#{name})" if name
-    name = "\033[36mgenerative#{name}\033[0m"
 
-    describe(name, generative: true, order: :generative, &block)
-  end
+  define_example_group_method :generative, { generative: true, order: :generative}
 
   class << self
     alias_method :data, :let

--- a/lib/generative/formatters.rb
+++ b/lib/generative/formatters.rb
@@ -1,13 +1,15 @@
 require 'rspec/core/formatters/progress_formatter'
+require 'rspec/core/formatters/console_codes'
 
 class RSpec::Core::Formatters::ProgressFormatter
-  def example_passed(example)
-    super(example)
 
-    if example.metadata[:generative]
-      output.print detail_color('.')
+  alias super_example_passed example_passed
+
+  def example_passed(example)
+    if example.example.metadata[:generative]
+      output.print RSpec::Core::Formatters::ConsoleCodes.wrap('.', :detail)
     else
-      output.print success_color('.')
+      super_example_passed(example)
     end
   end
 end


### PR DESCRIPTION
This changes the reopening of ProgressFormatter so that it doesn't give
an error; example_passed was not available as super. (also the printing changed)

The definition of the generative test method is also changed, so that it
works. This lost some coloring on the name maybe.

I'm not able to run the tests locally, but I think something else is wonky?
Is there still interest in this library? 
