### PR TITLE
Update README to encourage less verbose formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ end
 
 ```
 --color
---format progress
+--format Generative::Formatter
 --require generative
 ```
 
@@ -79,7 +79,7 @@ required arguments:
 ```
 $ generative
 + GENERATIVE_COUNT=10_000
-+ rspec --require generative --format Generative --tag generative
++ rspec --require generative --format Generative::Formatter --tag generative
 Run options: include {:generative=>true}
 
 String


### PR DESCRIPTION
Once you get past five or ten generative tests the progress formatter is so verbose it can cause CI problems (i.e. we've had Travis nodes running out of memory during runs).

Just updating the README a little to discourage the verbose formatting.

I might even update it later to have a different progress formatter that only shows 1 blue dot per set of generative tests or something.