### PR TITLE
Print description of example group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
   - ruby-head
 matrix:
   allow_failures:

--- a/generative.gemspec
+++ b/generative.gemspec
@@ -10,7 +10,7 @@ authors = {
 
 Gem::Specification.new do |gem|
   gem.name          = 'generative'
-  gem.version       = '0.2.3'
+  gem.version       = '0.2.4'
   gem.authors       = authors.keys
   gem.email         = authors.values
   gem.description   = "Generative and property-based testing for RSpec"

--- a/lib/generative/formatters.rb
+++ b/lib/generative/formatters.rb
@@ -37,7 +37,8 @@ module Generative
       output.puts if @group_level == 0
 
       if generative?(example_group)
-        output.puts "#{current_indentation}#{detail_color('generative')}"
+        group_description = "#{example_group.description} (generative)"
+        output.puts "#{current_indentation}#{detail_color(group_description)}"
 
         @group_level += 1
         example_group.examples.each do |example|

--- a/lib/generative/rake_task.rb
+++ b/lib/generative/rake_task.rb
@@ -8,7 +8,7 @@ module Generative
 
       self.name = :generative if name == :spec
 
-      desc "Run Generative specs" unless Rake.application.last_comment
+      desc "Run Generative specs" unless Rake.application.last_description
 
       options = %w[
         --require generative


### PR DESCRIPTION
Previously, generative swallowed the description of the example group and printed only
```
description
```
which can be a little annoying. With this change, the formatter prints
```
some example group description (generative)
```
instead.

I also fixed a Rake deprecation while at it