### PR TITLE
Optionally require `forwardable`

### DIFF
--- a/lib/generative.rb
+++ b/lib/generative.rb
@@ -1,4 +1,7 @@
 require 'rspec/core'
+if RUBY_DESCRIPTION
+  require 'forwardable'
+end
 
 module Generative
 

--- a/lib/generative.rb
+++ b/lib/generative.rb
@@ -1,7 +1,5 @@
 require 'rspec/core'
-if RUBY_DESCRIPTION
-  require 'forwardable'
-end
+require 'forwardable'
 
 module Generative
 


### PR DESCRIPTION
Newer versions of Ruby moved `Forwardable`
into a `forwardable` module.

Hey @justincampbell if you have a change to take a peek please do. If not I'll probably go ahead and merge in the next day or so.

Fixes #29 