### PR TITLE
Travis: update CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.1.10
-  - 2.2.5
-  - 2.3.1
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
   - ruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known