### PR TITLE
Configure RSpec to not use monkey-patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ would a `let`. Then, write your `it`/`specify` blocks as usual (while keeping
 in mind that the input could be anything).
 
 ```rb
-describe String do
+RSpec.describe String do
   let(:string) { "abc" }
 
   describe "#reverse" do
@@ -73,7 +73,7 @@ end
 
 Alternatively, you can modify existing specs in a minimally intrusive way by just adding two tags to an existing context and using the fact that `data` is just an alias for `let`:
 ```ruby
-describe String do
+RSpec.describe String do
   describe "#reverse", generative: true, order: :generative do
     let(:string) { rand(12345).to_s }
 
@@ -171,7 +171,7 @@ Generative.register_generator(:bar, Bar }
 You can then use your generators using the `generate` helper.
 
 ```rb
-describe String do
+RSpec.describe String do
   let(:string) { "abc" }
 
   describe "#reverse" do

--- a/spec/generative/generator_manager_spec.rb
+++ b/spec/generative/generator_manager_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Generative::GeneratorManager do
+RSpec.describe Generative::GeneratorManager do
 
   subject { Generative::GeneratorManager.new }
 

--- a/spec/generative/ordering_spec.rb
+++ b/spec/generative/ordering_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Generative::ORDERING do
+RSpec.describe Generative::ORDERING do
   let(:ordering) { Generative::ORDERING }
 
   around do |example|

--- a/spec/generative/rake_task_spec.rb
+++ b/spec/generative/rake_task_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'generative/rake_task'
 
-describe Generative::RakeTask do
+RSpec.describe Generative::RakeTask do
   let(:task) { Generative::RakeTask.new(*args) }
   let(:args) { [] }
 

--- a/spec/generative_spec.rb
+++ b/spec/generative_spec.rb
@@ -2,7 +2,7 @@ require 'generative'
 
 Generative.register_generator(:string) { "a" * rand(255) }
 
-describe String do
+RSpec.describe String do
   let(:string) { "abc" }
 
   describe "#length" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,4 +20,5 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   #config.order = 'random'
+  config.disable_monkey_patching!
 end


### PR DESCRIPTION
This PR configures RSpec not to use monkey-patching.

See https://relishapp.com/rspec/rspec-core/v/3-8/docs/configuration/zero-monkey-patching-mode

