### PR TITLE
CI: Use Ruby 2.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.4
+  - 2.5
+  - 2.6
   - ruby-head
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.4.6
   - 2.5.5
-  - 2.6.2
+  - 2.6.3
   - ruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known