### PR TITLE
Drop unused test_files directive from gemspec

### DIFF
--- a/generative.gemspec
+++ b/generative.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |file| File.basename file }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'rspec', '>= 3.0'


### PR DESCRIPTION
The test_files directive is not used for anything in RubyGems.org any longer.