### PR TITLE
CHANGELOG: Add versions, dates and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,30 @@
 # Changelog
 
-## 0.2.0
+## Unreleased
+
+https://github.com/justincampbell/generative/compare/v0.2.4...master
+
+## 0.2.4 (2016-09-15)
+
+https://github.com/justincampbell/generative/compare/v0.2.4...v0.2.4
+
+## 0.2.3 (2014-12-16)
+
+https://github.com/justincampbell/generative/compare/v0.2.2...v0.2.3
+
+## 0.2.2 (2014-12-08)
+
+https://github.com/justincampbell/generative/compare/v0.2.0...v0.2.2
+
+## 0.2.0 (2014-08-13)
 
 * Drop support for RSpec 2
 * Update RSpec integration to support RSpec 3 final (@jessitron)
 
-## 0.1.0
+## 0.1.0 (2013-12-18)
 
 * Add support for RSpec 2
 
-## 0.0.1
+## 0.0.1 (2013-11-21)
 
 * Initial release


### PR DESCRIPTION
This adds some skeletal structure to the CHANGELOG document.

- each version from Tags described
- a compare link for each
- an Unreleased section